### PR TITLE
[FIX JENKINS-41978] - Fix NPE when an invalid PEM is being decoded.

### DIFF
--- a/src/main/java/jenkins/bouncycastle/api/PEMEncodable.java
+++ b/src/main/java/jenkins/bouncycastle/api/PEMEncodable.java
@@ -152,6 +152,10 @@ public final class PEMEncodable {
 
             Object object = parser.readObject();
 
+            if (object == null) {
+                throw new IOException("Could not parse PEM, only key pairs, private keys, public keys and certificates are supported");
+            }
+
             JcaPEMKeyConverter kConv = new JcaPEMKeyConverter().setProvider("BC");
 
             // handle supported PEM formats.

--- a/src/test/java/jenkins/bouncycastle/EncodignDecodingTest.java
+++ b/src/test/java/jenkins/bouncycastle/EncodignDecodingTest.java
@@ -29,6 +29,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import java.io.File;
+import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.security.PublicKey;
@@ -237,4 +238,9 @@ public class EncodignDecodingTest {
         assertNotNull(pemEnc.toPublicKey());
     }
 
+    @Test(expected = IOException.class)
+    @Issue(value = "JENKINS-41978")
+    public void testInvalidPEM() throws Exception {
+        PEMEncodable.decode(FileUtils.readFileToString(getResourceFile("invalid.pem")));
+    }
 }

--- a/src/test/resources/invalid.pem
+++ b/src/test/resources/invalid.pem
@@ -1,0 +1,1 @@
+---INVALID PEM---


### PR DESCRIPTION
[JENKINS-41978](https://issues.jenkins-ci.org/browse/JENKINS-41978)

@reviewbybees