### PR TITLE
[JENKINS-53074] Upgrade to bc1.60

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
   </parent>
 
   <artifactId>bouncycastle-api</artifactId>
-  <version>2.54.0-SNAPSHOT</version>
+  <version>2.60.3-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <name>bouncycastle API Plugin</name>
@@ -65,7 +65,7 @@
   </scm>
 
   <properties>
-    <jenkins.version>2.54</jenkins.version>
+    <jenkins.version>2.60.3</jenkins.version>
     <java.level>8</java.level>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
   </parent>
 
   <artifactId>bouncycastle-api</artifactId>
-  <version>2.60.3-SNAPSHOT</version>
+  <version>2.17-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <name>bouncycastle API Plugin</name>

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcpkix-jdk15on</artifactId>
-      <version>1.59</version>
+      <version>1.60</version>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -29,11 +29,11 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.33</version>
+    <version>3.19</version>
   </parent>
 
   <artifactId>bouncycastle-api</artifactId>
-  <version>2.16.4-SNAPSHOT</version>
+  <version>2.54.0-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <name>bouncycastle API Plugin</name>
@@ -65,7 +65,8 @@
   </scm>
 
   <properties>
-    <jenkins.version>2.16</jenkins.version>
+    <jenkins.version>2.54</jenkins.version>
+    <java.level>8</java.level>
   </properties>
 
   <repositories>

--- a/src/main/java/jenkins/bouncycastle/api/PEMEncodable.java
+++ b/src/main/java/jenkins/bouncycastle/api/PEMEncodable.java
@@ -70,7 +70,7 @@ import org.bouncycastle.pkcs.PKCSException;
 import org.bouncycastle.util.encoders.Base64;
 
 /**
- * A class that provides an API to manager PEM format, providing additional methods to handle Keys, Certificates,
+ * A class that provides an API to manage PEM format, providing additional methods to handle Keys, Certificates,
  * Fingerprints, etc The supported algorithms will depend on the underlying version of BouncyCastle
  *
  * @since 1.0


### PR DESCRIPTION
See [JENKINS-53074](https://issues.jenkins-ci.org/browse/JENKINS-53074), which doesn't really say anything additional.

It's a good idea to keep up to date with these sorts of dependencies so let's move forward to the latest version. There is no indication from the League that there are any public API changes involved in this version. This Jenkins plugin wraps a very small surface of the bouncycastle library. None of the wrapped portions are affected. A few pieces of the Jenkins ecosystem use a couple of other components in the library, most notably KeyPairGenerator. All that I have found use high-level APIs, which haven't changed in this bouncycastle release.

I've also included a couple of other items to make this more current, which seem valuable with this sort of library. Or to correct a wording typo. If reviewers prefer, I can separate those out to a different PR or ignore them.