### PR TITLE
Update bouncycastle to 1.64

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.19</version>
+    <version>3.50</version>
   </parent>
 
   <artifactId>bouncycastle-api</artifactId>
@@ -40,11 +40,11 @@
   <description>
     This plugin provides an stable API to Bouncy Castle related tasks.
   </description>
-  <url>http://wiki.jenkins-ci.org/display/JENKINS/Bouncy+Castle+API+Plugin</url>
+  <url>https://wiki.jenkins-ci.org/display/JENKINS/Bouncy+Castle+API+Plugin</url>
   <licenses>
     <license>
       <name>The MIT license</name>
-      <url>http://www.opensource.org/licenses/mit-license.php</url>
+      <url>https://www.opensource.org/licenses/mit-license.php</url>
       <distribution>repo</distribution>
     </license>
   </licenses>
@@ -87,7 +87,7 @@
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcpkix-jdk15on</artifactId>
-      <version>1.60</version>
+      <version>1.63</version>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.50</version>
+    <version>3.55</version>
   </parent>
 
   <artifactId>bouncycastle-api</artifactId>
@@ -87,7 +87,7 @@
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcpkix-jdk15on</artifactId>
-      <version>1.63</version>
+      <version>1.64</version>
     </dependency>
   </dependencies>
 </project>

--- a/src/main/java/jenkins/bouncycastle/api/InstallBouncyCastleJCAProvider.java
+++ b/src/main/java/jenkins/bouncycastle/api/InstallBouncyCastleJCAProvider.java
@@ -24,7 +24,6 @@
 
 package jenkins.bouncycastle.api;
 
-import hudson.model.Computer;
 import hudson.remoting.ChannelProperty;
 import hudson.slaves.SlaveComputer;
 import java.io.IOException;

--- a/src/test/java/jenkins/bouncycastle/EncodignDecodingTest.java
+++ b/src/test/java/jenkins/bouncycastle/EncodignDecodingTest.java
@@ -24,7 +24,6 @@
 
 package jenkins.bouncycastle;
 
-import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 


### PR DESCRIPTION
- HTTPs links
- Update parent POM
- Update bouncycastle to 1.63 https://www.bouncycastle.org/releasenotes.html