### PR TITLE
[JENKINS-66180] be tolerant in the presence of the BouncyCastle FIPS provider

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,42 +131,21 @@
     </dependency>
   </dependencies>
 
-  <!--  copy the BC jars to bc_jars in the plugins resources, and exclude them from WEB-INF/lib -->
   <build>
     <plugins>
       <plugin>
         <artifactId>maven-dependency-plugin</artifactId>
         <executions>
           <execution>
+            <!--  copy the bouncycastle jars so they will be in the java archive -->
             <id>copy-bc-jars</id>
             <goals>
               <goal>copy-dependencies</goal>
             </goals>
             <configuration>
-              <!--  there is no easy way to filter here, so do crude pass and then do the correct filter with build-helper-maven-plugin -->
+              <includeGroupIds>org.bouncycastle</includeGroupIds>
               <excludeTransitive>true</excludeTransitive>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>add-bc-jars</id>
-            <goals>
-              <goal>add-resource</goal>
-            </goals>
-            <configuration>
-              <resources>
-                <resource>
-                  <directory>${project.build.directory}/dependency</directory>
-                  <targetPath>bc_jars</targetPath>
-                  <filtering>false</filtering>
-                  <include>bc*.jar</include>
-                </resource>
-              </resources>
+              <outputDirectory>${project.build.directory}/extra-classes/WEB-INF/optional-lib/</outputDirectory>
             </configuration>
           </execution>
         </executions>
@@ -177,6 +156,8 @@
         <configuration>
           <!-- do not add bouncycastle jars to WEB-INF/lib as they get added dynamically to be compatible with bouncycastle fips-->
           <warSourceExcludes>WEB-INF/lib/bc*.jar</warSourceExcludes>
+          <!-- and add them back in but in so they are in WEB-INF/optional-lib/ so we can load them dynamically -->
+          <webappDirectory>${project.build.directory}/extra-classes/</webappDirectory>
         </configuration>
       </plugin>
     </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,14 @@
   </pluginRepositories>
 
   <dependencies>
+    <!--
+      The BouncyCastle jars are exposed as regular dependencies to other plugins who depend on this plugin on the build classpath.
+      The JARs are not added to the plugin in the normal way though, rather they are conditionally injected into the classpath at initialisation time.
+      This allows plugin compilation etc to work as normal, however if the JVM has been configured using BouncyCastle FIPS jars for FIPS compliance we will not inject 
+      incompatible classes or try to register a non fips compliant Provider.
+      The FIPS and non FIPS versions of BouncyCastle are mostly but not completely API compatible if the consumer steers clear of any deprecated APIs or low level APIS.
+      This may cause some plugins that depend on this to blow up at runtime (e.g SAML), but without this even more things would go bang.
+    -->
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcpkix-jdk15on</artifactId>
@@ -108,5 +116,69 @@
         <version>3.19.0</version>
         <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.kohsuke</groupId>
+      <artifactId>access-modifier-suppressions</artifactId>
+      <version>${access-modifier-checker.version}</version>
+      <scope>provided</scope> <!-- not needed at runtime -->
+      <exclusions>
+        <exclusion>
+          <!-- Upper bounds and comes from core -->
+          <groupId>org.kohsuke</groupId>
+          <artifactId>access-modifier-annotation</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
   </dependencies>
+
+  <!--  copy the BC jars to bc_jars in the plugins resources, and exclude them from WEB-INF/lib -->
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>copy-bc-jars</id>
+            <goals>
+              <goal>copy-dependencies</goal>
+            </goals>
+            <configuration>
+              <!--  there is no easy way to filter here, so do crude pass and then do the correct filter with build-helper-maven-plugin -->
+              <excludeTransitive>true</excludeTransitive>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>add-bc-jars</id>
+            <goals>
+              <goal>add-resource</goal>
+            </goals>
+            <configuration>
+              <resources>
+                <resource>
+                  <directory>${project.build.directory}/dependency</directory>
+                  <targetPath>bc_jars</targetPath>
+                  <filtering>false</filtering>
+                  <include>bc*.jar</include>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.jenkins-ci.tools</groupId>
+        <artifactId>maven-hpi-plugin</artifactId>
+        <configuration>
+          <!-- do not add bouncycastle jars to WEB-INF/lib as they get added dynamically to be compatible with bouncycastle fips-->
+          <warSourceExcludes>WEB-INF/lib/bc*.jar</warSourceExcludes>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/src/main/java/jenkins/bouncycastle/api/BouncyCastlePlugin.java
+++ b/src/main/java/jenkins/bouncycastle/api/BouncyCastlePlugin.java
@@ -54,15 +54,14 @@ public class BouncyCastlePlugin extends Plugin {
                 LOG.log(Level.INFO, "No optional-libs found, for non RealJenkinsRule this is fine and can be ignored.");
             } else {
                 LOG.log(Level.WARNING, "No optional-libs not found at {0}, BouncyCastle APIs will be unavailable causing strange runtime issues.", optionalLibDir);
-                // TODO do we want to do this or continue in a best effort?
+                // fail fast, most likely a packaging issue
                 throw new IllegalStateException("BouncyCastle libs are missing from WEB-INF/optional-libs");
             }
         } else {
-            //final List<String> bcJars = getResourceFiles();
             AntClassLoader cl = (AntClassLoader) this.getWrapper().classLoader;
 
             for (File optionalLib : optionalLibs) {
-                LOG.log(Level.INFO, () -> "Inserting " + optionalLib + " into bouncycastle-api plugin classpath");
+                LOG.log(Level.CONFIG, () -> "Inserting " + optionalLib + " into bouncycastle-api plugin classpath");
                 cl.addPathComponent(optionalLib);
             }
         }

--- a/src/main/java/jenkins/bouncycastle/api/BouncyCastlePlugin.java
+++ b/src/main/java/jenkins/bouncycastle/api/BouncyCastlePlugin.java
@@ -27,9 +27,9 @@ public class BouncyCastlePlugin extends Plugin {
         Provider p = Security.getProvider("BCFIPS");
         isActive = (p == null);
 
-        LOG.log(Level.INFO,
+        LOG.log(Level.CONFIG,
                 isActive ? "BouncyCastle Providers from BouncyCastle API plugin will be active" :
-                           "Detected the precence of the BouncyCastle FIPS provider, the regular BouncyCastle jars will not be avaialble.");
+                           "Detected the presence of the BouncyCastle FIPS provider, the regular BouncyCastle JARs will not be available.");
     }
 
     @Override

--- a/src/main/java/jenkins/bouncycastle/api/BouncyCastlePlugin.java
+++ b/src/main/java/jenkins/bouncycastle/api/BouncyCastlePlugin.java
@@ -1,0 +1,96 @@
+package jenkins.bouncycastle.api;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.charset.Charset;
+import java.security.Provider;
+import java.security.Security;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.kohsuke.accmod.restrictions.suppressions.SuppressRestrictedWarnings;
+import hudson.Plugin;
+import jenkins.util.AntClassLoader;
+
+@SuppressWarnings("deprecation") // there is no other way to achieve this at the correct lifecycle point
+@Restricted(NoExternalUse.class) // just for Jenkins access not part of the API
+public class BouncyCastlePlugin extends Plugin {
+
+    private static final Logger LOG = Logger.getLogger(BouncyCastlePlugin.class.getName());
+
+    private static final boolean isActive;
+
+    static {
+        // BouncyCastle FIPS is installed in the JVM, we can not install over the top of it so do not try
+        Provider p = Security.getProvider("BCFIPS");
+        isActive = (p == null);
+
+        LOG.log(Level.INFO,
+                isActive ? "BouncyCastle Providers from BouncyCastle API plugin will be active" :
+                           "Detected the precence of the BouncyCastle FIPS provider, the regular BouncyCastle jars will not be avaialble.");
+    }
+
+    @Override
+    @SuppressRestrictedWarnings(jenkins.util.AntClassLoader.class) // we are messing with the classloader and it has not changed in many many years
+    public void start() throws Exception {
+        if (!isActive) {
+            // Alternative BouncyCastle is installed do no not insert these libraries
+            return;
+        }
+        // this is the hairy part.
+        // add the BouncyCastle APIs into the classpath for other plugins (and this plugin to use!)
+        /*
+         * Whilst plugins that have code may go boom before this with class loading issues, extensions (at this point)
+         * have not been discovered, so this would only affect people using the deprecated `Plugin` class (like we are!)
+         */
+        final List<String> bcJars = getResourceFiles();
+        AntClassLoader cl = (AntClassLoader) this.getWrapper().classLoader;
+
+        // grab the needed resources
+        for (String jar : bcJars) {
+            File jarFile = locateJar(jar);
+            LOG.log(Level.INFO, () -> "Inserting " + jar + " into bouncycastle-api plugin classpath");
+            cl.addPathComponent(jarFile);
+        }
+        SecurityProviderInitializer.addSecurityProvider();
+    }
+
+    public static boolean isActive() {
+        return isActive;
+    }
+
+    private static File locateJar(String name) throws IOException {
+        LOG.log(Level.FINE, "Attempting to locate BouncyCastle Jar {0}", name);
+        URL resourceURL = BouncyCastlePlugin.class.getResource("/bc_jars/" + name);
+        if (resourceURL == null) {
+            throw new IOException("Could not locate " + name + " in plugin resources");
+        }
+        try {
+            File f = new File(resourceURL.toURI());
+            LOG.log(Level.FINE, () -> "Located " + name + "  at " + f.getAbsolutePath());
+            return f;
+        } catch (URISyntaxException ex) {
+            throw new IOException("Could not locate file for " + name + " with URI " + resourceURL, ex);
+        }
+    }
+
+    private static List<String> getResourceFiles() throws IOException {
+        LOG.log(Level.FINE, "Searching for BouncyCastle Jars...");
+
+        try (InputStream in = BouncyCastlePlugin.class.getResourceAsStream("/bc_jars");
+                InputStreamReader isr = new InputStreamReader(in, Charset.defaultCharset());
+                BufferedReader br = new BufferedReader(isr)) {
+            List<String> filenames = br.lines().collect(Collectors.toList());
+            LOG.log(Level.FINE, () -> "Found the following BouncyCastle Jars: " + filenames.toString());
+            return filenames;
+        }
+    }
+}

--- a/src/main/java/jenkins/bouncycastle/api/InstallBouncyCastleJCAProvider.java
+++ b/src/main/java/jenkins/bouncycastle/api/InstallBouncyCastleJCAProvider.java
@@ -31,7 +31,6 @@ import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.logging.Logger;
 import javax.annotation.Nonnull;
 
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
@@ -47,7 +46,6 @@ import jenkins.security.MasterToSlaveCallable;
  */
 public class InstallBouncyCastleJCAProvider extends MasterToSlaveCallable<Boolean, Exception> {
 
-    private static Logger LOG = Logger.getLogger(InstallBouncyCastleJCAProvider.class.getName());
     /**
      * Ensure standardized serialization.
      */

--- a/src/main/java/jenkins/bouncycastle/api/InstallBouncyCastleJCAProvider.java
+++ b/src/main/java/jenkins/bouncycastle/api/InstallBouncyCastleJCAProvider.java
@@ -31,6 +31,7 @@ import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.logging.Logger;
 import javax.annotation.Nonnull;
 
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
@@ -46,6 +47,7 @@ import jenkins.security.MasterToSlaveCallable;
  */
 public class InstallBouncyCastleJCAProvider extends MasterToSlaveCallable<Boolean, Exception> {
 
+    private static Logger LOG = Logger.getLogger(InstallBouncyCastleJCAProvider.class.getName());
     /**
      * Ensure standardized serialization.
      */
@@ -105,6 +107,9 @@ public class InstallBouncyCastleJCAProvider extends MasterToSlaveCallable<Boolea
      * @throws LinkageError if there was a classloading issue on the remote agent.
      */
     public static void on(@Nonnull Channel channel) throws IOException, InterruptedException {
+        if (!BouncyCastlePlugin.isActive()) {
+            return;
+        }
         Future future = channel.getProperty(BOUNCYCASTLE_REGISTERED);
 
         try {

--- a/src/main/java/jenkins/bouncycastle/api/SecurityProviderInitializer.java
+++ b/src/main/java/jenkins/bouncycastle/api/SecurityProviderInitializer.java
@@ -29,36 +29,23 @@ import java.util.logging.Logger;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
-import hudson.Plugin;
-
 /**
  * Initialization class to register Bouncy Castle as a security provider.
  * 
  * @since 1.0
  */
-public class SecurityProviderInitializer extends Plugin {
-   
-    private static final Logger LOGGER = Logger.getLogger(SecurityProviderInitializer.class.getName());
-    
-    static{
-        /*
-         * FIXME: We should do it with the @Initializer but some other plugins are loading before this one 
-         * and failing because of BC not being registered. It seems to be a core related bug that is not 
-         * resolving the dependency graph correctly.
-         */
+public class SecurityProviderInitializer {
 
-        addSecurityProvider();
-    }
-    
+    private static final Logger LOGGER = Logger.getLogger(SecurityProviderInitializer.class.getName());
+
     /**
      * Initializes JVM security to Bouncy Castle. This initialization should be done before any plugin is loaded in
      * order to ensure that the provider is available to any plugin that needs it and that we are the first to register
      * it.
      * 
      */
-    //@Initializer(before = InitMilestone.STARTED)
     @Restricted(NoExternalUse.class)
-    public static void addSecurityProvider() {
+    static void addSecurityProvider() {
         LOGGER.fine("Initializing Bouncy Castle security provider.");
         BcProviderRegistration.register();
         LOGGER.fine("Bouncy Castle security provider initialized.");

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,0 +1,4 @@
+<?jelly escape-by-default='true'?>
+<div>
+  This plugin provides a stable API to Bouncy Castle related tasks..
+</div>

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,4 +1,4 @@
 <?jelly escape-by-default='true'?>
 <div>
-  This plugin provides a stable API to Bouncy Castle related tasks..
+  This plugin provides a stable API to Bouncy Castle related tasks.
 </div>


### PR DESCRIPTION
[JENKINS-66180](https://issues.jenkins.io/browse/JENKINS-66180)

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->

   The most common way of running a JVM based app in FIPS compliance mode
    is to use the Bouncy Castle FIPS provider.

    This provider uses the same package structure as the regular one, but
    lacks support for some algorithms and some classes are different).
    Because of this if we just try and register the BouncyCastle Provider as
    normal we will end up
    1. subverting the FIPS compliance of the JVM
    2. likely failing due to invalid class / incompatable classes causing
       plugin initialisation errors, causing dependent plugins to also not
       initialise.

    Dependant plugins can often (but not always) be adapted to use either
    the FIPS apis or the regular ones (mostly this in an excersize in not
    using deprecated APIs!) but also ensuring that no alrorithm is asked for
    that is not FIPS compliant.   In either case this would need changes in
    those plugins, but for the plugins that need no changes they should
    function regardless, so now we do not unconditionally register any
    provider in either the controller or the agent.

    The first thing we do is check for the prescence of the BouncyCastle
    FIPS provider (using the BCFIPS provider string), if that is present
    then this plugin effectively becomes a no-op plugin with the exception
    of the PEM helper class.

    if the FIPS provider is not present then the plugin dynamically updates
    the classpath to inject the regualr bouncycastle libraries.

    for plugins that depend on this plugin no changes should be needed as
    long as everything is running in non FIPS mode.

    For the plugin to also work in the presence of the FIPS provider they
    need to
    1. not use any non fips approved algorithms
    2. use defaults (for keystore end factories) etc rather than hard coding
       vvalues
    3. not use deprecated API
    4. self check at runtime that things are still working as expected.