### PR TITLE
[JENKINS-66563] adapt to public API rather than hacks

### DIFF
--- a/src/main/java/jenkins/bouncycastle/api/BouncyCastlePlugin.java
+++ b/src/main/java/jenkins/bouncycastle/api/BouncyCastlePlugin.java
@@ -62,7 +62,8 @@ public class BouncyCastlePlugin extends Plugin {
                 throw new IllegalStateException("BouncyCastle libs are missing from WEB-INF/optional-libs");
             }
         } else {
-            if (Jenkins.getVersion().isNewerThan(new VersionNumber("2.312"))) {
+            VersionNumber version = Jenkins.getVersion();
+            if (version != null && version.isNewerThan(new VersionNumber("2.312"))) {
                 // TODO remove reflection when baseline > 2.312
                 // https://github.com/jenkinsci/jenkins/pull/5711
                 // and add <useBeta>true</useBeta> to the pom properties


### PR DESCRIPTION
This allows the plugin to be compatible also with the new experimental Classloaders
in Jenkins 2.311 which @basil has put effort into improving.
(https://github.com/jenkinsci/jenkins/pull/5698)

Uses reflection to access the new API from jenkinsci/jenkins#5711 until the plugin baseline moves on to a newer version.

Tested locally against a Jenkins 2.313-SNAPSHOT installing the plugin correctly registers BC provider.

Tried to write a RealJenkinsRule test - but tests run before the package is made so the `optional-lib` is not found. unclear if making it an IntegrationTest and running in `verify` would then fix the issue, but I am assuming that this is not supported by the `RealJenkinsRule` yet.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
