### PR TITLE
Bump `jenkins.version` from 2.222.4 to 2.319.1 to use new API without reflection

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,9 +68,10 @@
   <properties>
     <revision>2.26</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.version>2.222.4</jenkins.version>
+    <jenkins.version>2.319.1</jenkins.version>
     <java.level>8</java.level>
     <bouncycastleVersion>1.69</bouncycastleVersion>
+    <useBeta>true</useBeta>
   </properties>
 
   <repositories>


### PR DESCRIPTION
Using the new API added in jenkinsci/jenkins#5711.