### PR TITLE
Bump parent POM from 4.37 to 4.38

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.37</version>
+    <version>4.38</version>
     <relativePath />
   </parent>
 


### PR DESCRIPTION
A release of this would help us do Java 17 testing of this plugin in the plugin BOM repository. CC @jtnord